### PR TITLE
docs: permanent left-nav sidebar on docs site + prominent README link

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,12 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/pages.yml'
+  # Build (but do not deploy) on PRs so docs changes are validated before merge.
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -13,10 +19,9 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run
-# in-progress and latest queued. Do not cancel in-progress runs.
+# Serialize runs per ref; never cancel an in-progress deploy.
 concurrency:
-  group: 'pages'
+  group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -41,9 +46,10 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         # Defaults to uploading ./_site produced by the Jekyll build above.
 
-  # Deploy the built site to GitHub Pages.
+  # Deploy the built site to GitHub Pages — only from main (never on PRs).
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 [![CodeQL](https://github.com/armandcismaru/DeepTraderX/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/armandcismaru/DeepTraderX/actions/workflows/github-code-scanning/codeql)
 [![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/)
 
+> ### 📖 Documentation
+> **[Read the full documentation site →](https://armandcismaru.github.io/DeepTraderX/)**
+> Architecture · trading agents · the ML model · configuration · deployment.
+> (Source lives in [`docs/`](docs/); automated agents should start with [AGENTS.md](AGENTS.md).)
+
 This repository was created as part of my final individual project for the MEng Computer Science 4th year dissertation. It aims to explore the dynamics of a high performing, Deep Learning based trader, trained solely on data derived from the observation of Level-2 data from the Limit Order Book (LOB) of a simulated financial exchange. The project is using the [Threaded Bristol Stock Exchange (TBSE)](https://github.com/MichaelRol/Threaded-Bristol-Stock-Exchange) which was built with the purpose of replicating the asynchronous and parallel nature of real life markets, being a multithreaded extension of the [Bristol Stock Exchange (BSE)](https://github.com/davecliff/BristolStockExchange), created by Dave Cliff.
 
 The results of my research indicate positive results of DeepTraderX (DTX) versus the other, well established, public-domain literature. In some cases the profits are overwhelmingly higher. All the details can be found in my [thesis](fz19792_meng_dissertation.pdf). 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,13 +6,37 @@ description: >-
   Documentation for DeepTraderX (DTX/DTR) — a deep-learning trading agent
   competing inside the Threaded Bristol Stock Exchange (TBSE), a multi-threaded
   limit-order-book market simulator.
-theme: jekyll-theme-cayman
 
 # Project pages are served from https://<user>.github.io/<repo>/, so the site
-# must know its base path for theme assets and internal links to resolve.
+# must know its base path for internal links to resolve.
 # Update these if the repo is renamed or served from a custom domain.
 url: "https://armandcismaru.github.io"
 baseurl: "/DeepTraderX"
+
+# Presentation is handled by the custom two-column layout in
+# _layouts/default.html (permanent left-hand navigation sidebar). Force every
+# page to use it rather than relying on a gem theme.
+defaults:
+  - scope:
+      path: ""
+      type: pages
+    values:
+      layout: default
+
+# Left-sidebar navigation (rendered by _layouts/default.html). Order matters.
+nav:
+  - title: Overview
+    url: /
+  - title: Architecture
+    url: /architecture.html
+  - title: Trader Agents
+    url: /trader-agents.html
+  - title: Data & ML Model
+    url: /data-and-ml.html
+  - title: Configuration & Running
+    url: /configuration-and-running.html
+  - title: Deployment
+    url: /deployment.html
 
 # README.md is promoted to the site index by the jekyll-readme-index plugin
 # (bundled with GitHub Pages); .md links between docs are rewritten to .html by

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% if page.title %}{{ page.title }} · {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  {% if page.description or site.description %}<meta name="description" content="{{ page.description | default: site.description }}">{% endif %}
+  <style>
+    :root {
+      --accent:#0969da; --bg:#ffffff; --side-bg:#f6f8fa; --border:#d0d7de;
+      --text:#1f2328; --muted:#656d76; --sidebar-w:280px;
+    }
+    * { box-sizing:border-box; }
+    body {
+      margin:0; color:var(--text); background:var(--bg); line-height:1.6;
+      font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+      -webkit-font-smoothing:antialiased;
+    }
+    a { color:var(--accent); text-decoration:none; }
+    a:hover { text-decoration:underline; }
+
+    .layout { display:flex; align-items:flex-start; }
+
+    /* Permanent left sidebar / table of contents */
+    .sidebar {
+      position:sticky; top:0; height:100vh; width:var(--sidebar-w);
+      flex:0 0 var(--sidebar-w); overflow-y:auto;
+      background:var(--side-bg); border-right:1px solid var(--border); padding:24px 18px;
+    }
+    .sidebar .brand { font-weight:600; font-size:18px; color:var(--text); display:block; }
+    .sidebar .tagline { color:var(--muted); font-size:12.5px; margin:2px 0 18px; }
+    .sidebar nav ul { list-style:none; margin:0; padding:0; }
+    .sidebar nav li { margin:2px 0; }
+    .sidebar nav a {
+      display:block; padding:6px 10px; border-radius:6px; color:var(--text); font-size:14px;
+    }
+    .sidebar nav a:hover { background:#eaeef2; text-decoration:none; }
+    .sidebar nav a.active { background:var(--accent); color:#fff; font-weight:600; }
+    .sidebar .repo-link {
+      margin-top:20px; padding-top:14px; border-top:1px solid var(--border);
+      font-size:13px; color:var(--muted);
+    }
+
+    /* Content column */
+    .content { flex:1 1 auto; min-width:0; padding:40px 48px; max-width:880px; }
+    .content > :first-child { margin-top:0; }
+    .content h1, .content h2, .content h3, .content h4 { line-height:1.25; margin-top:1.5em; margin-bottom:.6em; }
+    .content h1 { padding-bottom:.3em; border-bottom:1px solid var(--border); }
+    .content h2 { padding-bottom:.3em; border-bottom:1px solid var(--border); }
+    .content table { border-collapse:collapse; margin:1em 0; display:block; width:max-content; max-width:100%; overflow-x:auto; }
+    .content th, .content td { border:1px solid var(--border); padding:6px 13px; }
+    .content th { background:var(--side-bg); }
+    .content tr:nth-child(2n) td { background:#f6f8fa; }
+    .content code {
+      background:rgba(175,184,193,.2); padding:.2em .4em; border-radius:6px; font-size:85%;
+      font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+    }
+    .content pre {
+      background:var(--side-bg); border:1px solid var(--border); border-radius:6px;
+      padding:16px; overflow:auto; line-height:1.45;
+    }
+    .content pre code { background:none; padding:0; font-size:85%; }
+    .content blockquote { margin:1em 0; padding:0 1em; color:var(--muted); border-left:.25em solid var(--border); }
+    .content img { max-width:100%; }
+    .content hr { height:1px; border:0; background:var(--border); margin:1.6em 0; }
+
+    /* Stack the sidebar on top on narrow screens */
+    @media (max-width:800px) {
+      .layout { display:block; }
+      .sidebar { position:static; height:auto; width:auto; border-right:none; border-bottom:1px solid var(--border); }
+      .content { padding:24px 18px; max-width:none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <a class="brand" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+      <div class="tagline">Documentation &amp; reference</div>
+      <nav>
+        <ul>
+          {% for item in site.nav %}
+          <li>
+            <a href="{{ item.url | relative_url }}"{% if page.url == item.url %} class="active"{% endif %}>{{ item.title }}</a>
+          </li>
+          {% endfor %}
+        </ul>
+      </nav>
+      <div class="repo-link">↗ <a href="https://github.com/armandcismaru/DeepTraderX">GitHub repository</a></div>
+    </aside>
+    <main class="content">
+      {{ content }}
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Follow-up to #45. Two documentation usability improvements:

1. **Permanent left-hand navigation sidebar** on the docs site. Adds a custom
   two-column Jekyll layout (`docs/_layouts/default.html`) with a sticky
   sidebar that lists every page and highlights the current one, replacing the
   single-column Cayman theme. `_config.yml` drops the gem theme, adds the `nav`
   list that drives the sidebar, and forces `layout: default` on all pages.

2. **Prominent docs link in the repo README.** A "📖 Documentation" callout near
   the top of `README.md` links to https://armandcismaru.github.io/DeepTraderX/
   so anyone landing on the repo can find the docs immediately.

Also hardens CI: `pages.yml` now **builds** the site on pull requests (so docs
changes are validated before merge) while **deploy** stays gated to `main`.

## Notes
- The Jekyll build is exercised by this PR's `build` check (new PR trigger), so a
  green check confirms the site compiles before merge.
- On merge, the site redeploys to GitHub Pages with the new sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
